### PR TITLE
Add feed fetch error tracking and UI warnings

### DIFF
--- a/tasks/fetch_feed_task.py
+++ b/tasks/fetch_feed_task.py
@@ -46,11 +46,16 @@ class FetchFeedTask(threading.Thread):
             response = requests.get(self.url, headers=headers, timeout=30)
             self.handle_response(response)
         except requests.exceptions.RequestException as e:
-            print(f"Error fetching {self.url}: {e}")
+            error_msg = f"Error fetching {self.url}: {e}"
+            print(error_msg)
+            self.record_fetch_error(str(e))
 
     def handle_response(self, response):
         if response.status_code == 200:
             print(f"Successfully fetched: {self.url}")
+            
+            # Clear any previous fetch errors on success
+            self.clear_fetch_error()
             
             # Process articles first to extract title
             feed_title = self.process_articles(response.text)
@@ -141,7 +146,9 @@ class FetchFeedTask(threading.Thread):
             except Exception as e:
                 print(f"Error updating content: {e}")
         else:
+            error_msg = f"HTTP {response.status_code}"
             print(f"Failed to fetch: {self.url} with status code: {response.status_code}")
+            self.record_fetch_error(error_msg)
 
     def is_duplicate(self, doc_hash):
         """
@@ -183,3 +190,32 @@ class FetchFeedTask(threading.Thread):
         except Exception as e:
             print(f"Error processing articles from {self.url}: {e}")
             return None
+
+    def record_fetch_error(self, error_message):
+        """Record a fetch error in the feed registry."""
+        url_hash = hashlib.sha256(self.url.encode('utf-8')).hexdigest()
+        try:
+            res = requests.get(f"{self.registry_url}/{url_hash}")
+            if res.status_code == 200:
+                reg_doc = res.json()
+                reg_doc["last_fetch_error"] = error_message
+                reg_doc["last_fetch_at"] = datetime.now().isoformat()
+                requests.put(f"{self.registry_url}/{url_hash}", json=reg_doc)
+                print(f"Recorded fetch error for {self.url}: {error_message}")
+        except Exception as e:
+            print(f"Failed to record fetch error: {e}")
+
+    def clear_fetch_error(self):
+        """Clear any previous fetch error in the feed registry."""
+        url_hash = hashlib.sha256(self.url.encode('utf-8')).hexdigest()
+        try:
+            res = requests.get(f"{self.registry_url}/{url_hash}")
+            if res.status_code == 200:
+                reg_doc = res.json()
+                if "last_fetch_error" in reg_doc:
+                    del reg_doc["last_fetch_error"]
+                reg_doc["last_fetch_at"] = datetime.now().isoformat()
+                requests.put(f"{self.registry_url}/{url_hash}", json=reg_doc)
+                print(f"Cleared fetch error for {self.url}")
+        except Exception as e:
+            print(f"Failed to clear fetch error: {e}")

--- a/ui/src/components/FeedColumn.vue
+++ b/ui/src/components/FeedColumn.vue
@@ -7,6 +7,8 @@ interface Feed {
   title?: string;
   category?: string;
   favicon_url?: string;
+  last_fetch_error?: string;
+  last_fetch_at?: string;
 }
 
 const feeds = ref<Feed[]>([])
@@ -146,6 +148,7 @@ const handleFaviconError = (event: Event) => {
           <span v-if="feed.category" class="category-tag">{{ feed.category }}</span>
         </div>
         <div class="feed-actions">
+          <button v-if="feed.last_fetch_error" class="warning-btn" :title="`Fetch error: ${feed.last_fetch_error}`" disabled>⚠️</button>
           <button @click="openFeedInNewTab(feed.url)" class="open-link-btn" title="Open Feed">🔗</button>
           <button @click="startRename(feed)" class="rename-btn" title="Rename Feed">✏️</button>
           <button @click="deleteFeed(feed._id)" class="delete-btn" title="Delete Feed">×</button>
@@ -254,12 +257,19 @@ h2 {
   display: flex;
   gap: 5px;
 }
-.open-link-btn, .rename-btn, .delete-btn {
+.warning-btn, .open-link-btn, .rename-btn, .delete-btn {
   background: none;
   border: none;
   font-size: 1.2rem;
   cursor: pointer;
   padding: 0 5px;
+}
+.warning-btn {
+  color: #ff9800;
+  cursor: help;
+}
+.warning-btn:disabled {
+  opacity: 1;
 }
 .open-link-btn {
   color: #999;


### PR DESCRIPTION
Features:
- Track fetch errors in feed documents (last_fetch_error, last_fetch_at)
- Record errors when feed fetch fails (network errors, HTTP errors)
- Clear errors automatically on successful fetch
- Display warning icon (⚠️) next to feeds with errors
- Show error details in tooltip on hover
- Errors auto-clear on next successful fetch (handles systematic issues)

Backend changes:
- Updated FetchFeedTask.fetch_url() to call record_fetch_error() on exception
- Updated FetchFeedTask.handle_response() to clear errors on HTTP 200
- Added record_fetch_error() and clear_fetch_error() helper methods
- Errors recorded with timestamp for troubleshooting

Frontend changes:
- Extended Feed interface with last_fetch_error and last_fetch_at fields
- Added conditional warning button in feed actions
- Warning icon only shown when last_fetch_error exists
- Tooltip displays full error message on hover
- Styled with orange color and help cursor