### PR TITLE
feat: approval gate, cancellation, and session timeline API

### DIFF
--- a/api/approval_routes.py
+++ b/api/approval_routes.py
@@ -61,31 +61,35 @@ def list_pending_approvals():
     if not request_ids:
         return jsonify([])
 
-    pending = []
-    for rid in request_ids:
-        if isinstance(rid, bytes):
-            rid = rid.decode("utf-8")
-        pending_key = f"{_APPROVAL_PENDING_PREFIX}{rid}"
-        decision_key = f"{_APPROVAL_DECISION_PREFIX}{rid}"
-        try:
-            data = redis_client.hgetall(pending_key)
-            if not data:
-                continue
-            # Skip already-decided requests
-            if redis_client.exists(decision_key):
-                continue
-            # Decode bytes keys/values
-            entry = {
-                (k.decode("utf-8") if isinstance(k, bytes) else k): (
-                    v.decode("utf-8") if isinstance(v, bytes) else v
-                )
-                for k, v in data.items()
-            }
-            pending.append(entry)
-        except Exception:
-            logger.exception("Failed to read approval request %s", rid)
-
+    pending = [
+        entry
+        for rid in request_ids
+        if (entry := _read_pending_request(redis_client, rid)) is not None
+    ]
     return jsonify(pending)
+
+
+def _read_pending_request(redis_client, rid) -> dict | None:
+    """Read a single pending approval request from Redis, or return None."""
+    if isinstance(rid, bytes):
+        rid = rid.decode("utf-8")
+    pending_key = f"{_APPROVAL_PENDING_PREFIX}{rid}"
+    decision_key = f"{_APPROVAL_DECISION_PREFIX}{rid}"
+    try:
+        data = redis_client.hgetall(pending_key)
+        if not data:
+            return None
+        if redis_client.exists(decision_key):
+            return None
+        return {
+            (k.decode("utf-8") if isinstance(k, bytes) else k): (
+                v.decode("utf-8") if isinstance(v, bytes) else v
+            )
+            for k, v in data.items()
+        }
+    except Exception:
+        logger.exception("Failed to read approval request")
+        return None
 
 
 @approval_blueprint.route("/approvals/<request_id>/approve", methods=["POST"])
@@ -112,7 +116,7 @@ def _decide(request_id: str, decision: str):
     try:
         data = redis_client.hgetall(pending_key)
     except Exception:
-        logger.exception("Failed to read approval request %s", request_id)
+        logger.exception("Failed to read approval request")
         abort(500, description="Failed to read approval request")
 
     if not data:
@@ -128,11 +132,6 @@ def _decide(request_id: str, decision: str):
     decision_key = f"{_APPROVAL_DECISION_PREFIX}{request_id}"
     redis_client.set(decision_key, decision, ex=_APPROVAL_TTL)
 
-    logger.info(
-        "Approval decision '%s' for request %s by user %s",
-        decision,
-        request_id,
-        getattr(g, "user_id", "unknown"),
-    )
+    logger.info("Approval decision recorded")
 
     return jsonify({"request_id": request_id, "decision": decision})

--- a/api/approval_routes.py
+++ b/api/approval_routes.py
@@ -1,0 +1,138 @@
+"""REST API for agent approval workflow.
+
+Operators can list pending approval requests for destructive tool calls
+and approve or deny them.  The approval gate in :class:`TracingMCPClient`
+polls Redis for decisions.
+"""
+
+import logging
+
+from flask import Blueprint, abort, g, jsonify, request
+
+from api.auth import jwt_required
+from api.extensions import get_redis_client
+from api.userspace_ops import get_userspace
+
+logger = logging.getLogger(__name__)
+
+_ADMIN_ROLE = "admin"
+
+_APPROVAL_PENDING_PREFIX = "approval:pending:"
+_APPROVAL_DECISION_PREFIX = "approval:decision:"
+_APPROVAL_QUEUE_PREFIX = "approval:queue:"
+_APPROVAL_TTL = 600
+
+approval_blueprint = Blueprint("approvals", __name__)
+
+
+def _user_owns_userspace(userspace_id: str) -> bool:
+    doc = get_userspace(userspace_id)
+    if not doc:
+        return False
+    return doc.get("owner_user_id") == g.user_id
+
+
+@approval_blueprint.route("/approvals/pending", methods=["GET"])
+@jwt_required
+def list_pending_approvals():
+    """List pending approval requests for the caller's userspaces.
+
+    Query params
+    ------------
+    userspace : required UUID (must be owned by caller or caller is admin).
+    """
+    userspace = request.args.get("userspace")
+    if not userspace:
+        abort(400, description="'userspace' parameter is required")
+    if not _user_owns_userspace(userspace) and g.user_role != _ADMIN_ROLE:
+        abort(403, description="Access denied")
+
+    redis_client = get_redis_client()
+    if not redis_client:
+        return jsonify([])
+
+    queue_key = f"{_APPROVAL_QUEUE_PREFIX}{userspace}"
+    try:
+        request_ids = redis_client.lrange(queue_key, 0, 49)
+    except Exception:
+        logger.exception("Failed to read approval queue")
+        return jsonify([])
+
+    if not request_ids:
+        return jsonify([])
+
+    pending = []
+    for rid in request_ids:
+        if isinstance(rid, bytes):
+            rid = rid.decode("utf-8")
+        pending_key = f"{_APPROVAL_PENDING_PREFIX}{rid}"
+        decision_key = f"{_APPROVAL_DECISION_PREFIX}{rid}"
+        try:
+            data = redis_client.hgetall(pending_key)
+            if not data:
+                continue
+            # Skip already-decided requests
+            if redis_client.exists(decision_key):
+                continue
+            # Decode bytes keys/values
+            entry = {
+                (k.decode("utf-8") if isinstance(k, bytes) else k): (
+                    v.decode("utf-8") if isinstance(v, bytes) else v
+                )
+                for k, v in data.items()
+            }
+            pending.append(entry)
+        except Exception:
+            logger.exception("Failed to read approval request %s", rid)
+
+    return jsonify(pending)
+
+
+@approval_blueprint.route("/approvals/<request_id>/approve", methods=["POST"])
+@jwt_required
+def approve_request(request_id: str):
+    """Approve a pending destructive action."""
+    return _decide(request_id, "approved")
+
+
+@approval_blueprint.route("/approvals/<request_id>/deny", methods=["POST"])
+@jwt_required
+def deny_request(request_id: str):
+    """Deny a pending destructive action."""
+    return _decide(request_id, "denied")
+
+
+def _decide(request_id: str, decision: str):
+    """Write an approval decision to Redis."""
+    redis_client = get_redis_client()
+    if not redis_client:
+        abort(503, description="Redis unavailable")
+
+    pending_key = f"{_APPROVAL_PENDING_PREFIX}{request_id}"
+    try:
+        data = redis_client.hgetall(pending_key)
+    except Exception:
+        logger.exception("Failed to read approval request %s", request_id)
+        abort(500, description="Failed to read approval request")
+
+    if not data:
+        abort(404, description="Approval request not found or expired")
+
+    # Ownership check
+    userspace = data.get(b"userspace") or data.get("userspace")
+    if isinstance(userspace, bytes):
+        userspace = userspace.decode("utf-8")
+    if userspace and not _user_owns_userspace(userspace) and g.user_role != _ADMIN_ROLE:
+        abort(403, description="Access denied")
+
+    decision_key = f"{_APPROVAL_DECISION_PREFIX}{request_id}"
+    redis_client.set(decision_key, decision, ex=_APPROVAL_TTL)
+
+    logger.info(
+        "Approval decision '%s' for request %s by user %s",
+        decision,
+        request_id,
+        getattr(g, "user_id", "unknown"),
+    )
+
+    return jsonify({"request_id": request_id, "decision": decision})

--- a/api/session_routes.py
+++ b/api/session_routes.py
@@ -1,10 +1,14 @@
 """REST API for session logs (agent runs and chat turns)."""
 
+import logging
+
 from flask import Blueprint, abort, g, jsonify, request
 
 from api.auth import jwt_required
-from api.extensions import get_session_logger
+from api.extensions import get_redis_client, get_session_logger
 from api.userspace_ops import get_userspace
+
+logger = logging.getLogger(__name__)
 
 _ADMIN_ROLE = "admin"
 
@@ -43,8 +47,8 @@ def list_sessions():
     except ValueError:
         abort(400, description="limit and offset must be integers")
 
-    logger = get_session_logger()
-    sessions = logger.list_sessions(userspace=userspace, limit=limit, offset=offset)
+    sl = get_session_logger()
+    sessions = sl.list_sessions(userspace=userspace, limit=limit, offset=offset)
     return jsonify(sessions)
 
 
@@ -52,8 +56,8 @@ def list_sessions():
 @jwt_required
 def get_session(session_id: str):
     """Fetch a single session log by ID."""
-    logger = get_session_logger()
-    session = logger.get_session(session_id)
+    sl = get_session_logger()
+    session = sl.get_session(session_id)
     if not session:
         abort(404, description="Session not found")
 
@@ -62,3 +66,47 @@ def get_session(session_id: str):
         abort(403, description="Access denied")
 
     return jsonify(session)
+
+
+@session_blueprint.route("/sessions/<session_id>/steps", methods=["GET"])
+@jwt_required
+def get_session_steps(session_id: str):
+    """Return step-level traces for a session."""
+    sl = get_session_logger()
+    session = sl.get_session(session_id)
+    if not session:
+        abort(404, description="Session not found")
+
+    userspace = session.get("userspace")
+    if userspace and not _user_owns_userspace(userspace):
+        abort(403, description="Access denied")
+
+    steps = sl.get_steps(session_id)
+    return jsonify(steps)
+
+
+@session_blueprint.route("/sessions/<session_id>/cancel", methods=["POST"])
+@jwt_required
+def cancel_session(session_id: str):
+    """Request cancellation of a running agent session."""
+    sl = get_session_logger()
+    session = sl.get_session(session_id)
+    if not session:
+        abort(404, description="Session not found")
+
+    userspace = session.get("userspace")
+    if userspace and not _user_owns_userspace(userspace):
+        abort(403, description="Access denied")
+
+    if session.get("status") != "running":
+        abort(409, description="Session is not running")
+
+    redis_client = get_redis_client()
+    if not redis_client:
+        abort(503, description="Redis unavailable")
+
+    cancel_key = f"session:cancel:{session_id}"
+    redis_client.set(cancel_key, "1", ex=600)
+
+    logger.info("Session %s cancel requested by user %s", session_id, getattr(g, "user_id", "unknown"))
+    return jsonify({"session_id": session_id, "status": "cancel_requested"})

--- a/api/session_routes.py
+++ b/api/session_routes.py
@@ -11,6 +11,8 @@ from api.userspace_ops import get_userspace
 logger = logging.getLogger(__name__)
 
 _ADMIN_ROLE = "admin"
+_ACCESS_DENIED = "Access denied"
+_SESSION_NOT_FOUND = "Session not found"
 
 session_blueprint = Blueprint("sessions", __name__)
 
@@ -37,7 +39,7 @@ def list_sessions():
     userspace = request.args.get("userspace")
     if userspace:
         if not _user_owns_userspace(userspace):
-            abort(403, description="Access denied")
+            abort(403, description=_ACCESS_DENIED)
     elif g.user_role != _ADMIN_ROLE:
         abort(400, description="'userspace' parameter is required")
 
@@ -59,11 +61,11 @@ def get_session(session_id: str):
     sl = get_session_logger()
     session = sl.get_session(session_id)
     if not session:
-        abort(404, description="Session not found")
+        abort(404, description=_SESSION_NOT_FOUND)
 
     userspace = session.get("userspace")
     if userspace and not _user_owns_userspace(userspace):
-        abort(403, description="Access denied")
+        abort(403, description=_ACCESS_DENIED)
 
     return jsonify(session)
 
@@ -75,11 +77,11 @@ def get_session_steps(session_id: str):
     sl = get_session_logger()
     session = sl.get_session(session_id)
     if not session:
-        abort(404, description="Session not found")
+        abort(404, description=_SESSION_NOT_FOUND)
 
     userspace = session.get("userspace")
     if userspace and not _user_owns_userspace(userspace):
-        abort(403, description="Access denied")
+        abort(403, description=_ACCESS_DENIED)
 
     steps = sl.get_steps(session_id)
     return jsonify(steps)
@@ -92,11 +94,11 @@ def cancel_session(session_id: str):
     sl = get_session_logger()
     session = sl.get_session(session_id)
     if not session:
-        abort(404, description="Session not found")
+        abort(404, description=_SESSION_NOT_FOUND)
 
     userspace = session.get("userspace")
     if userspace and not _user_owns_userspace(userspace):
-        abort(403, description="Access denied")
+        abort(403, description=_ACCESS_DENIED)
 
     if session.get("status") != "running":
         abort(409, description="Session is not running")
@@ -108,5 +110,5 @@ def cancel_session(session_id: str):
     cancel_key = f"session:cancel:{session_id}"
     redis_client.set(cancel_key, "1", ex=600)
 
-    logger.info("Session %s cancel requested by user %s", session_id, getattr(g, "user_id", "unknown"))
+    logger.info("Session cancel requested")
     return jsonify({"session_id": session_id, "status": "cancel_requested"})

--- a/api/validation.py
+++ b/api/validation.py
@@ -128,6 +128,15 @@ class AgentConfigBase(BaseModel):
     linked_entity_id: Optional[str] = Field(
         None, description="ID of a specific event or trend this agent is managing"
     )
+    max_retries: int = Field(
+        3, ge=0, le=10, description="Max automatic retries for transient tool failures"
+    )
+    require_approval: bool = Field(
+        False, description="Require human approval before executing destructive tool calls"
+    )
+    approval_timeout_seconds: int = Field(
+        300, ge=30, le=3600, description="Seconds to wait for approval before timing out"
+    )
 
     @field_validator("schedule_interval")
     @classmethod

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from api.auth import auth_blueprint, JWT_SECRET_KEY  # Import JWT_SECRET_KEY
 from api.agent_routes import agent_blueprint
 from api.userspace_routes import userspace_blueprint
 from api.session_routes import session_blueprint
+from api.approval_routes import approval_blueprint
 from api.telemetry import configure_telemetry  # Moved to top
 
 from tasks.scheduler import scheduler
@@ -51,6 +52,7 @@ csrf.exempt(chat_blueprint)
 csrf.exempt(mcp_blueprint)
 csrf.exempt(agent_blueprint)
 csrf.exempt(session_blueprint)
+csrf.exempt(approval_blueprint)  # NOSONAR (python:S4502) — JWT Bearer auth, not cookies
 
 if (
     is_test_mode 
@@ -75,6 +77,7 @@ app.register_blueprint(auth_blueprint, url_prefix="/api/auth")
 app.register_blueprint(agent_blueprint, url_prefix="/api")
 app.register_blueprint(userspace_blueprint, url_prefix="/api")
 app.register_blueprint(session_blueprint, url_prefix="/api")
+app.register_blueprint(approval_blueprint, url_prefix="/api")
 
 
 @app.route("/", methods=["GET"])

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ csrf.exempt(chat_blueprint)
 csrf.exempt(mcp_blueprint)
 csrf.exempt(agent_blueprint)
 csrf.exempt(session_blueprint)
-csrf.exempt(approval_blueprint)  # NOSONAR (python:S4502) — JWT Bearer auth, not cookies
+csrf.exempt(approval_blueprint)  # NOSONAR
 
 if (
     is_test_mode 

--- a/tasks/agent_orchestrator.py
+++ b/tasks/agent_orchestrator.py
@@ -13,7 +13,7 @@ from api.validation import ALLOWED_LOGIC_MODULES, AgentStatus, AgentTriggerType
 from api.userspace_ops import resolve_llm_config
 from tasks.agent_config_migration import migrate_legacy_agent_configs
 from tasks.session_logger import SessionLogger, SESSION_TYPE_SCHEDULED, SESSION_TYPE_ON_NEW_ARTICLE
-from tasks.tracing_mcp_client import TracingMCPClient
+from tasks.tracing_mcp_client import TracingMCPClient, AgentCancelledException
 
 logger = logging.getLogger(__name__)
 
@@ -472,7 +472,12 @@ class AgentOrchestrator(threading.Thread):
                     mcp_client=self.mcp_client,
                     session_logger=self.session_logger,
                     session_id=counters["session_id"],
+                    redis_client=self.redis_client,
                     max_retries=agent_config.get("max_retries", 3),
+                    require_approval=agent_config.get("require_approval", False),
+                    approval_timeout=agent_config.get("approval_timeout_seconds", 300),
+                    userspace=userspace,
+                    agent_name=agent_config.get("name") or logic_module_path,
                 )
 
                 # Pass agent config and other relevant data
@@ -487,6 +492,13 @@ class AgentOrchestrator(threading.Thread):
                     {"last_run_at": datetime.now(timezone.utc).isoformat()},
                 )
 
+            except AgentCancelledException:
+                logger.info(
+                    "Agent %s cancelled by operator during session %s.",
+                    agent_config.get("_id"),
+                    counters["session_id"],
+                )
+                raise
             except Exception as e:
                 logger.error(
                     f"Failed to execute logic for agent {agent_config.get('_id')} from {logic_module_path}: {e}"

--- a/tasks/session_logger.py
+++ b/tasks/session_logger.py
@@ -249,7 +249,10 @@ class SessionLogger:
         try:
             yield counters
         except Exception as exc:
-            status = STATUS_ERROR
+            if type(exc).__name__ == "AgentCancelledException":
+                status = STATUS_CANCELLED
+            else:
+                status = STATUS_ERROR
             error_msg = str(exc)
             raise
         finally:

--- a/tasks/tracing_mcp_client.py
+++ b/tasks/tracing_mcp_client.py
@@ -34,6 +34,17 @@ DESTRUCTIVE_TOOLS: set[str] = frozenset(
 
 _MAX_SUMMARY_LEN = 500
 
+# Redis key prefixes for the approval workflow
+_APPROVAL_PENDING_PREFIX = "approval:pending:"
+_APPROVAL_DECISION_PREFIX = "approval:decision:"
+_APPROVAL_QUEUE_PREFIX = "approval:queue:"
+_SESSION_CANCEL_PREFIX = "session:cancel:"
+_APPROVAL_TTL = 600  # seconds
+
+
+class AgentCancelledException(Exception):
+    """Raised when an operator cancels a running agent session."""
+
 
 def _truncate(value: str, max_len: int = _MAX_SUMMARY_LEN) -> str:
     if len(value) <= max_len:
@@ -52,9 +63,20 @@ class TracingMCPClient:
         A :class:`SessionLogger` instance for persisting steps.
     session_id
         The session ID to attach steps to.
+    redis_client
+        Optional Redis client for approval gate and cancellation checks.
     max_retries
         Maximum number of automatic retries for transient (``retryable``) tool
-        failures.  ``0`` disables retries.
+        failures.  ``1`` means no retries (single attempt).
+    require_approval
+        When ``True``, destructive tool calls pause and wait for human
+        approval via Redis before executing.
+    approval_timeout
+        Seconds to wait for an approval decision before timing out.
+    userspace
+        The userspace UUID for this agent run (used in approval requests).
+    agent_name
+        Human-readable agent name for approval request context.
     """
 
     def __init__(
@@ -63,12 +85,22 @@ class TracingMCPClient:
         session_logger: SessionLogger,
         session_id: str,
         *,
+        redis_client: Any = None,
         max_retries: int = 3,
+        require_approval: bool = False,
+        approval_timeout: int = 300,
+        userspace: str = "",
+        agent_name: str = "",
     ) -> None:
         self._inner = mcp_client
         self._session_logger = session_logger
         self._session_id = session_id
+        self._redis = redis_client
         self._max_retries = max_retries
+        self._require_approval = require_approval
+        self._approval_timeout = approval_timeout
+        self._userspace = userspace
+        self._agent_name = agent_name
 
     # Expose logger/session_id so agent_logic can opt-in to LLM tracing
     @property
@@ -80,12 +112,170 @@ class TracingMCPClient:
         return self._session_id
 
     # ------------------------------------------------------------------
-    # Proxied call_tool with tracing + retry
+    # Cancellation check
+    # ------------------------------------------------------------------
+
+    def _check_cancelled(self) -> None:
+        """Raise if the session has been cancelled by an operator."""
+        if self._redis:
+            try:
+                if self._redis.get(f"{_SESSION_CANCEL_PREFIX}{self._session_id}"):
+                    raise AgentCancelledException(
+                        f"Agent session {self._session_id} cancelled by operator"
+                    )
+            except AgentCancelledException:
+                raise
+            except Exception:
+                # Don't let Redis errors block execution
+                logger.debug("Could not check cancellation flag", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Approval gate
+    # ------------------------------------------------------------------
+
+    def _request_approval(self, tool_name: str, kwargs: dict) -> str:
+        """Submit an approval request and poll for a decision.
+
+        Returns ``"approved"``, ``"denied"``, or ``"timeout"``.
+        """
+        request_id = str(uuid.uuid4())
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Write the pending request
+        pending_key = f"{_APPROVAL_PENDING_PREFIX}{request_id}"
+        self._redis.hset(
+            pending_key,
+            mapping={
+                "request_id": request_id,
+                "session_id": self._session_id,
+                "tool_name": tool_name,
+                "input_summary": _truncate(str(kwargs)),
+                "risk_level": "destructive",
+                "requested_at": now,
+                "agent_name": self._agent_name,
+                "userspace": self._userspace,
+            },
+        )
+        self._redis.expire(pending_key, _APPROVAL_TTL)
+
+        # Add to per-userspace queue for listing
+        queue_key = f"{_APPROVAL_QUEUE_PREFIX}{self._userspace}"
+        self._redis.lpush(queue_key, request_id)
+        self._redis.expire(queue_key, _APPROVAL_TTL)
+
+        # Record pending step
+        self._session_logger.add_step(
+            self._session_id,
+            {
+                "step_id": str(uuid.uuid4()),
+                "step_type": "tool_call",
+                "tool_name": tool_name,
+                "input_summary": _truncate(str(kwargs)),
+                "status": "pending_approval",
+                "risk_level": "destructive",
+                "correlation_id": request_id,
+                "attempt": 0,
+                "timestamp": now,
+            },
+        )
+
+        logger.info(
+            "Approval requested for %s (request_id=%s, agent=%s)",
+            tool_name,
+            request_id,
+            self._agent_name,
+        )
+
+        # Poll for decision
+        decision_key = f"{_APPROVAL_DECISION_PREFIX}{request_id}"
+        deadline = time.monotonic() + self._approval_timeout
+        while time.monotonic() < deadline:
+            decision = self._redis.get(decision_key)
+            if decision:
+                if isinstance(decision, bytes):
+                    decision = decision.decode("utf-8")
+                logger.info(
+                    "Approval decision for %s: %s (request_id=%s)",
+                    tool_name,
+                    decision,
+                    request_id,
+                )
+                return decision
+            # Also check for session cancellation while waiting
+            self._check_cancelled()
+            time.sleep(1.0)
+
+        logger.warning(
+            "Approval timed out for %s (request_id=%s, timeout=%ds)",
+            tool_name,
+            request_id,
+            self._approval_timeout,
+        )
+        return "timeout"
+
+    # ------------------------------------------------------------------
+    # Proxied call_tool with tracing + approval + retry
     # ------------------------------------------------------------------
 
     def call_tool(self, tool_name: str, **kwargs: Any) -> Any:
         """Call a tool on the inner client, recording a step trace for each attempt."""
+        # Check for cancellation before each tool call
+        self._check_cancelled()
+
         risk_level = "destructive" if tool_name in DESTRUCTIVE_TOOLS else "normal"
+
+        # Approval gate for destructive tools
+        if (
+            self._require_approval
+            and risk_level == "destructive"
+            and self._redis
+        ):
+            decision = self._request_approval(tool_name, kwargs)
+            if decision == "denied":
+                step = {
+                    "step_id": str(uuid.uuid4()),
+                    "step_type": "tool_call",
+                    "tool_name": tool_name,
+                    "input_summary": _truncate(str(kwargs)),
+                    "status": "denied",
+                    "risk_level": "destructive",
+                    "error_code": "APPROVAL_DENIED",
+                    "error_message": "Destructive action denied by operator",
+                    "correlation_id": str(uuid.uuid4()),
+                    "attempt": 0,
+                    "latency_ms": 0,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+                self._session_logger.add_step(self._session_id, step)
+                return {
+                    "status": "error",
+                    "error_code": "APPROVAL_DENIED",
+                    "message": "Destructive action denied by operator",
+                    "retryable": False,
+                }
+            elif decision == "timeout":
+                step = {
+                    "step_id": str(uuid.uuid4()),
+                    "step_type": "tool_call",
+                    "tool_name": tool_name,
+                    "input_summary": _truncate(str(kwargs)),
+                    "status": "denied",
+                    "risk_level": "destructive",
+                    "error_code": "APPROVAL_TIMEOUT",
+                    "error_message": f"No approval received within {self._approval_timeout}s",
+                    "correlation_id": str(uuid.uuid4()),
+                    "attempt": 0,
+                    "latency_ms": 0,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+                self._session_logger.add_step(self._session_id, step)
+                return {
+                    "status": "error",
+                    "error_code": "APPROVAL_TIMEOUT",
+                    "message": f"No approval received within {self._approval_timeout}s",
+                    "retryable": False,
+                }
+            # "approved" — fall through to execute
 
         last_result = None
         for attempt in range(1, self._max_retries + 1):

--- a/tasks/tracing_mcp_client.py
+++ b/tasks/tracing_mcp_client.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # Tools whose execution has side-effects that are difficult or impossible to
 # reverse.  Used to tag steps with ``risk_level = "destructive"`` and to gate
 # execution behind the approval workflow when ``require_approval`` is enabled.
-DESTRUCTIVE_TOOLS: set[str] = frozenset(
+DESTRUCTIVE_TOOLS: frozenset[str] = frozenset(
     {
         "delete_issue",
         "delete_event",
@@ -214,6 +214,36 @@ class TracingMCPClient:
         return "timeout"
 
     # ------------------------------------------------------------------
+    # Approval rejection helpers
+    # ------------------------------------------------------------------
+
+    def _record_rejection(
+        self, tool_name: str, kwargs: dict, error_code: str, message: str,
+    ) -> dict:
+        """Record a denied/timeout step and return an error MCPResponse."""
+        step = {
+            "step_id": str(uuid.uuid4()),
+            "step_type": "tool_call",
+            "tool_name": tool_name,
+            "input_summary": _truncate(str(kwargs)),
+            "status": "denied",
+            "risk_level": "destructive",
+            "error_code": error_code,
+            "error_message": message,
+            "correlation_id": str(uuid.uuid4()),
+            "attempt": 0,
+            "latency_ms": 0,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        self._session_logger.add_step(self._session_id, step)
+        return {
+            "status": "error",
+            "error_code": error_code,
+            "message": message,
+            "retryable": False,
+        }
+
+    # ------------------------------------------------------------------
     # Proxied call_tool with tracing + approval + retry
     # ------------------------------------------------------------------
 
@@ -225,56 +255,19 @@ class TracingMCPClient:
         risk_level = "destructive" if tool_name in DESTRUCTIVE_TOOLS else "normal"
 
         # Approval gate for destructive tools
-        if (
-            self._require_approval
-            and risk_level == "destructive"
-            and self._redis
-        ):
+        if self._require_approval and risk_level == "destructive" and self._redis:
             decision = self._request_approval(tool_name, kwargs)
             if decision == "denied":
-                step = {
-                    "step_id": str(uuid.uuid4()),
-                    "step_type": "tool_call",
-                    "tool_name": tool_name,
-                    "input_summary": _truncate(str(kwargs)),
-                    "status": "denied",
-                    "risk_level": "destructive",
-                    "error_code": "APPROVAL_DENIED",
-                    "error_message": "Destructive action denied by operator",
-                    "correlation_id": str(uuid.uuid4()),
-                    "attempt": 0,
-                    "latency_ms": 0,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                }
-                self._session_logger.add_step(self._session_id, step)
-                return {
-                    "status": "error",
-                    "error_code": "APPROVAL_DENIED",
-                    "message": "Destructive action denied by operator",
-                    "retryable": False,
-                }
-            elif decision == "timeout":
-                step = {
-                    "step_id": str(uuid.uuid4()),
-                    "step_type": "tool_call",
-                    "tool_name": tool_name,
-                    "input_summary": _truncate(str(kwargs)),
-                    "status": "denied",
-                    "risk_level": "destructive",
-                    "error_code": "APPROVAL_TIMEOUT",
-                    "error_message": f"No approval received within {self._approval_timeout}s",
-                    "correlation_id": str(uuid.uuid4()),
-                    "attempt": 0,
-                    "latency_ms": 0,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                }
-                self._session_logger.add_step(self._session_id, step)
-                return {
-                    "status": "error",
-                    "error_code": "APPROVAL_TIMEOUT",
-                    "message": f"No approval received within {self._approval_timeout}s",
-                    "retryable": False,
-                }
+                return self._record_rejection(
+                    tool_name, kwargs,
+                    "APPROVAL_DENIED", "Destructive action denied by operator",
+                )
+            if decision == "timeout":
+                return self._record_rejection(
+                    tool_name, kwargs,
+                    "APPROVAL_TIMEOUT",
+                    f"No approval received within {self._approval_timeout}s",
+                )
             # "approved" — fall through to execute
 
         last_result = None

--- a/tests/test_approval_and_cancellation.py
+++ b/tests/test_approval_and_cancellation.py
@@ -279,7 +279,7 @@ class TestSessionContextCancellation:
         return mock_redis, pipe, stored
 
     def test_cancelled_exception_sets_cancelled_status(self):
-        mock_redis, pipe, stored = self._setup_redis_for_session()
+        mock_redis, pipe, _ = self._setup_redis_for_session()
         sl = SessionLogger(mock_redis)
 
         with pytest.raises(AgentCancelledException):
@@ -296,7 +296,7 @@ class TestSessionContextCancellation:
         assert last_doc["status"] == STATUS_CANCELLED
 
     def test_regular_exception_sets_error_status(self):
-        mock_redis, pipe, stored = self._setup_redis_for_session()
+        mock_redis, pipe, _ = self._setup_redis_for_session()
         sl = SessionLogger(mock_redis)
 
         with pytest.raises(ValueError):

--- a/tests/test_approval_and_cancellation.py
+++ b/tests/test_approval_and_cancellation.py
@@ -1,0 +1,388 @@
+"""Tests for Phase 2+3: Retry config, approval gate, cancellation, and API routes."""
+
+import json
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("ADMIN_PASSWORD", "test-password")
+
+import pytest
+
+from tasks.session_logger import (
+    SessionLogger,
+    STATUS_CANCELLED,
+    STATUS_ERROR,
+)
+from tasks.tracing_mcp_client import (
+    AgentCancelledException,
+    TracingMCPClient,
+    _APPROVAL_QUEUE_PREFIX,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_redis():
+    r = MagicMock()
+    return r
+
+
+@pytest.fixture
+def mock_session_logger():
+    return MagicMock(spec=SessionLogger)
+
+
+@pytest.fixture
+def mock_inner_client():
+    return MagicMock()
+
+
+def _make_tracing_client(
+    inner, sl, redis=None, require_approval=False, approval_timeout=2, max_retries=1
+):
+    return TracingMCPClient(
+        mcp_client=inner,
+        session_logger=sl,
+        session_id="sess-1",
+        redis_client=redis,
+        max_retries=max_retries,
+        require_approval=require_approval,
+        approval_timeout=approval_timeout,
+        userspace="ws-1",
+        agent_name="test-agent",
+    )
+
+
+# ===========================================================================
+# Cancellation
+# ===========================================================================
+
+
+class TestCancellation:
+    def test_cancelled_before_tool_call(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        mock_redis.get.return_value = b"1"  # cancel flag set
+        client = _make_tracing_client(
+            mock_inner_client, mock_session_logger, redis=mock_redis
+        )
+
+        with pytest.raises(AgentCancelledException):
+            client.call_tool("read_feed", userspace="ws-1")
+
+        # Tool should NOT have been called
+        mock_inner_client.call_tool.assert_not_called()
+
+    def test_not_cancelled_when_flag_absent(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        mock_redis.get.return_value = None
+        mock_inner_client.call_tool.return_value = {"status": "success", "data": {}}
+        client = _make_tracing_client(
+            mock_inner_client, mock_session_logger, redis=mock_redis
+        )
+
+        result = client.call_tool("read_feed", userspace="ws-1")
+        assert result["status"] == "success"
+
+    def test_cancellation_check_tolerates_redis_error(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        mock_redis.get.side_effect = ConnectionError("Redis down")
+        mock_inner_client.call_tool.return_value = {"status": "success", "data": {}}
+        client = _make_tracing_client(
+            mock_inner_client, mock_session_logger, redis=mock_redis
+        )
+
+        # Should NOT raise — Redis errors are swallowed
+        result = client.call_tool("read_feed", userspace="ws-1")
+        assert result["status"] == "success"
+
+    def test_no_cancellation_check_without_redis(
+        self, mock_inner_client, mock_session_logger
+    ):
+        mock_inner_client.call_tool.return_value = {"status": "success", "data": {}}
+        client = _make_tracing_client(mock_inner_client, mock_session_logger)
+
+        result = client.call_tool("read_feed", userspace="ws-1")
+        assert result["status"] == "success"
+
+
+# ===========================================================================
+# Approval gate
+# ===========================================================================
+
+
+class TestApprovalGate:
+    def test_approval_skipped_for_safe_tools(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        """Non-destructive tools bypass approval even when require_approval=True."""
+        mock_redis.get.return_value = None  # no cancel flag
+        mock_inner_client.call_tool.return_value = {"status": "success", "data": {}}
+        client = _make_tracing_client(
+            mock_inner_client,
+            mock_session_logger,
+            redis=mock_redis,
+            require_approval=True,
+        )
+
+        result = client.call_tool("read_feed", userspace="ws-1")
+        assert result["status"] == "success"
+        # No approval request written
+        mock_redis.hset.assert_not_called()
+
+    def test_approval_skipped_when_not_required(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        """Destructive tools execute without approval when require_approval=False."""
+        mock_redis.get.return_value = None
+        mock_inner_client.call_tool.return_value = {"status": "success", "data": {}}
+        client = _make_tracing_client(
+            mock_inner_client,
+            mock_session_logger,
+            redis=mock_redis,
+            require_approval=False,
+        )
+
+        result = client.call_tool("delete_feed", userspace="ws-1")
+        assert result["status"] == "success"
+        mock_redis.hset.assert_not_called()
+
+    def test_approved_action_executes(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        """When approved, the destructive tool call proceeds."""
+        # get() calls: 1st for cancel check, then approval polling returns "approved"
+        mock_redis.get.side_effect = [None, b"approved"]
+        mock_inner_client.call_tool.return_value = {"status": "success", "data": {}}
+        client = _make_tracing_client(
+            mock_inner_client,
+            mock_session_logger,
+            redis=mock_redis,
+            require_approval=True,
+            approval_timeout=5,
+        )
+
+        result = client.call_tool("delete_feed", userspace="ws-1")
+
+        assert result["status"] == "success"
+        mock_inner_client.call_tool.assert_called_once()
+        # Approval request was written
+        mock_redis.hset.assert_called_once()
+
+    def test_denied_action_returns_error(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        """When denied, the tool call is NOT executed."""
+        mock_redis.get.side_effect = [None, b"denied"]
+        client = _make_tracing_client(
+            mock_inner_client,
+            mock_session_logger,
+            redis=mock_redis,
+            require_approval=True,
+            approval_timeout=5,
+        )
+
+        result = client.call_tool("delete_feed", userspace="ws-1")
+
+        assert result["status"] == "error"
+        assert result["error_code"] == "APPROVAL_DENIED"
+        mock_inner_client.call_tool.assert_not_called()
+        # Denied step recorded
+        steps = [
+            c[0][1]
+            for c in mock_session_logger.add_step.call_args_list
+            if c[0][1].get("status") == "denied"
+        ]
+        assert len(steps) >= 1
+
+    def test_timeout_returns_error(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        """When no decision arrives within timeout, returns error."""
+        mock_redis.get.return_value = None  # never a decision
+        client = _make_tracing_client(
+            mock_inner_client,
+            mock_session_logger,
+            redis=mock_redis,
+            require_approval=True,
+            approval_timeout=1,  # 1 second timeout for fast test
+        )
+
+        result = client.call_tool("delete_feed", userspace="ws-1")
+
+        assert result["status"] == "error"
+        assert result["error_code"] == "APPROVAL_TIMEOUT"
+        mock_inner_client.call_tool.assert_not_called()
+
+    def test_approval_writes_to_redis_queue(
+        self, mock_inner_client, mock_session_logger, mock_redis
+    ):
+        """Approval request is written to Redis hash + queue."""
+        mock_redis.get.side_effect = [None, b"approved"]
+        mock_inner_client.call_tool.return_value = {"status": "success", "data": {}}
+        client = _make_tracing_client(
+            mock_inner_client,
+            mock_session_logger,
+            redis=mock_redis,
+            require_approval=True,
+            approval_timeout=5,
+        )
+
+        client.call_tool("delete_feed", userspace="ws-1")
+
+        # Verify hset was called with approval pending data
+        hset_call = mock_redis.hset.call_args
+        assert hset_call is not None
+        mapping = hset_call[1]["mapping"]
+        assert mapping["tool_name"] == "delete_feed"
+        assert mapping["userspace"] == "ws-1"
+        assert mapping["agent_name"] == "test-agent"
+
+        # Verify lpush to queue
+        mock_redis.lpush.assert_called_once()
+        queue_key = mock_redis.lpush.call_args[0][0]
+        assert queue_key == f"{_APPROVAL_QUEUE_PREFIX}ws-1"
+
+
+# ===========================================================================
+# Session context manager — cancellation status
+# ===========================================================================
+
+
+class TestSessionContextCancellation:
+    def _setup_redis_for_session(self):
+        """Create a mock Redis that stores session docs written via pipeline."""
+        mock_redis = MagicMock()
+        mock_redis.llen.return_value = 0
+        pipe = mock_redis.pipeline.return_value
+        pipe.execute.return_value = []
+
+        # Capture what pipeline.set() writes so finish_session can read it back
+        stored = {}
+
+        def fake_pipe_set(key, value, ex=None):
+            stored[key] = value
+
+        pipe.set.side_effect = fake_pipe_set
+
+        def fake_get(key):
+            return stored.get(key)
+
+        mock_redis.get.side_effect = fake_get
+
+        return mock_redis, pipe, stored
+
+    def test_cancelled_exception_sets_cancelled_status(self):
+        mock_redis, pipe, stored = self._setup_redis_for_session()
+        sl = SessionLogger(mock_redis)
+
+        with pytest.raises(AgentCancelledException):
+            with sl.session(
+                session_type="scheduled_agent",
+                userspace="ws-1",
+            ):
+                raise AgentCancelledException("cancelled by operator")
+
+        # Find the final persisted doc (last pipeline set call)
+        set_calls = [c for c in pipe.method_calls if c[0] == "set"]
+        assert len(set_calls) >= 2  # start + finish
+        last_doc = json.loads(set_calls[-1][1][1])
+        assert last_doc["status"] == STATUS_CANCELLED
+
+    def test_regular_exception_sets_error_status(self):
+        mock_redis, pipe, stored = self._setup_redis_for_session()
+        sl = SessionLogger(mock_redis)
+
+        with pytest.raises(ValueError):
+            with sl.session(
+                session_type="scheduled_agent",
+                userspace="ws-1",
+            ):
+                raise ValueError("something broke")
+
+        set_calls = [c for c in pipe.method_calls if c[0] == "set"]
+        assert len(set_calls) >= 2
+        last_doc = json.loads(set_calls[-1][1][1])
+        assert last_doc["status"] == STATUS_ERROR
+
+
+# ===========================================================================
+# Agent config schema fields
+# ===========================================================================
+
+
+class TestAgentConfigSchemaFields:
+    def test_default_values(self):
+        from api.validation import AgentConfigBase
+
+        config = AgentConfigBase(
+            name="test",
+            trigger_type="scheduled",
+            target_db="issues",
+            logic_module="tasks.agent_logic.create_event_from_articles",
+            schedule_interval="1h",
+        )
+        assert config.max_retries == 3
+        assert config.require_approval is False
+        assert config.approval_timeout_seconds == 300
+
+    def test_custom_values(self):
+        from api.validation import AgentConfigBase
+
+        config = AgentConfigBase(
+            name="test",
+            trigger_type="scheduled",
+            target_db="issues",
+            logic_module="tasks.agent_logic.create_event_from_articles",
+            schedule_interval="1h",
+            max_retries=5,
+            require_approval=True,
+            approval_timeout_seconds=600,
+        )
+        assert config.max_retries == 5
+        assert config.require_approval is True
+        assert config.approval_timeout_seconds == 600
+
+    def test_max_retries_bounds(self):
+        from pydantic import ValidationError
+        from api.validation import AgentConfigBase
+
+        with pytest.raises(ValidationError):
+            AgentConfigBase(
+                name="test",
+                trigger_type="scheduled",
+                target_db="issues",
+                logic_module="tasks.agent_logic.create_event_from_articles",
+                schedule_interval="1h",
+                max_retries=11,  # > 10
+            )
+
+    def test_approval_timeout_bounds(self):
+        from pydantic import ValidationError
+        from api.validation import AgentConfigBase
+
+        with pytest.raises(ValidationError):
+            AgentConfigBase(
+                name="test",
+                trigger_type="scheduled",
+                target_db="issues",
+                logic_module="tasks.agent_logic.create_event_from_articles",
+                schedule_interval="1h",
+                approval_timeout_seconds=10,  # < 30
+            )
+
+
+# ===========================================================================
+# STATUS_CANCELLED constant
+# ===========================================================================
+
+
+class TestStatusConstants:
+    def test_status_cancelled_exists(self):
+        assert STATUS_CANCELLED == "cancelled"


### PR DESCRIPTION
## Summary

- **Approval gate**: Destructive tool calls (delete_feed, delete_issue, publish_to_bluesky, etc.) can require human approval when `require_approval=True` in agent config. Redis-backed polling with configurable timeout (default 5min).
- **Cancellation**: Operators can cancel running agent sessions via `POST /api/sessions/<id>/cancel`. TracingMCPClient checks a Redis flag before each tool call and raises `AgentCancelledException` for clean termination with `STATUS_CANCELLED`.
- **Session timeline API**: `GET /api/sessions/<id>/steps` returns step-level traces. New approval routes: `GET /api/approvals/pending`, `POST /api/approvals/<id>/approve`, `POST /api/approvals/<id>/deny`.
- **Agent config fields**: `max_retries` (0-10, default 3), `require_approval` (bool), `approval_timeout_seconds` (30-3600, default 300).

Stacked on #124 (`feat/agent-observability`).

## Test plan

- [x] 238 existing + new tests pass (0 failures)
- [x] 17 new tests in `test_approval_and_cancellation.py` covering approval gate, cancellation, schema validation, session context status
- [ ] CI gates (ruff, pytest, Docker build)
- [ ] Manual: create agent with `require_approval=True`, trigger destructive action, approve/deny via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)