### PR TITLE
fix: restore issue context in Gemini chat and repair copy/download

### DIFF
--- a/api/llm/gemini.py
+++ b/api/llm/gemini.py
@@ -29,11 +29,13 @@ class GeminiProvider(LLMProvider):
 
     def create_chat_completion(self, messages, model, tools, tool_choice):
         # 1. Setup Config
-        system_instruction = None
-        # Extract system prompt if present
-        if messages and messages[0]["role"] == "system":
-            system_instruction = messages[0]["content"]
+        # Collect ALL leading system messages and combine into one system_instruction.
+        # The agent pipeline may insert multiple system messages (main prompt + context preamble).
+        system_parts = []
+        while messages and messages[0]["role"] == "system":
+            system_parts.append(messages[0]["content"])
             messages = messages[1:]
+        system_instruction = "\n\n".join(system_parts) if system_parts else None
 
         gemini_tools = self._convert_tools(tools)
         

--- a/ui/src/components/ChatPage.vue
+++ b/ui/src/components/ChatPage.vue
@@ -466,8 +466,10 @@ const downloadChat = async () => {
   const disposition = response.headers.get('Content-Disposition') ?? ''
   const match = disposition.match(/filename="?([^";]+)"?/)
   link.download = match?.[1] ?? 'chat.md'
+  document.body.appendChild(link)
   link.click()
-  URL.revokeObjectURL(url)
+  document.body.removeChild(link)
+  globalThis.setTimeout(() => URL.revokeObjectURL(url), 100)
 }
 
 const copyChat = async () => {
@@ -479,7 +481,17 @@ const copyChat = async () => {
       return
     }
     const markdown = await response.text()
-    await navigator.clipboard.writeText(markdown)
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(markdown)
+    } else {
+      const textarea = document.createElement('textarea')
+      textarea.value = markdown
+      textarea.style.cssText = 'position:fixed;opacity:0'
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textarea)
+    }
     copyStatus.value = 'Copied'
   } catch (error) {
     console.error('Failed to copy chat export:', error)


### PR DESCRIPTION
## Summary

- **Gemini context preamble dropped:** `run_agent` inserts the issue/article context as a second system message (index 1), but `gemini.py` only extracted the first system message as `system_instruction`. The second was passed to `_convert_message_to_gemini` which returns `None` for `role == "system"` — silently discarded. LLM never saw the issue context and asked the user for IDs it already had.
- **Download broken in Firefox:** `<a>.click()` without the element being in the DOM doesn't trigger a download reliably in Firefox. Fixed by appending/removing from `document.body`, and delaying `revokeObjectURL` by 100ms to avoid a race condition.
- **Copy broken in HTTP contexts:** `navigator.clipboard` is only available in secure contexts (HTTPS/localhost). Added `execCommand('copy')` fallback so copy works when the app is accessed over plain HTTP.

## Changes

- `api/llm/gemini.py` — collect **all** consecutive leading system messages into a single `system_instruction` instead of stopping at the first
- `ui/src/components/ChatPage.vue` — DOM-safe download link + clipboard fallback

## Test plan

- [ ] Open context chat on an issue, use "Find new coverage" quick action — LLM should search immediately without asking for an issue name/ID
- [ ] In ChatPage, load a session with issue context and send a message — LLM should use the issue context directly
- [ ] Click Download on a chat session — file should download in both Chrome and Firefox
- [ ] Click Copy on a chat session over HTTP — should copy successfully (or at least not silently fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)