### PR TITLE
fix: bump worker memory limit to 1Gi to stop OOMKill loop (0.8.1-rc.1)

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: moirai
 description: A Helm chart for the Morai - GenAI Press Review service
 type: application
-version: 0.7.2
-appVersion: "0.7.2"
+version: 0.8.1-rc.1
+appVersion: "0.8.1-rc.1"
 home: https://github.com/hlan-net/moirai
 icon: https://raw.githubusercontent.com/hlan-net/moirai/main/ui/public/favicon.ico
 sources:

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -53,14 +53,7 @@ spec:
           imagePullPolicy: {{ if eq .Values.api.image.tag "latest" }}Always{{ else }}{{ default "IfNotPresent" .Values.api.image.pullPolicy }}{{ end }}
           command: ["python", "run_worker.py"]
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-              ephemeral-storage: "1Gi"
-            limits:
-              cpu: 500m
-              memory: 512Mi
-              ephemeral-storage: "2Gi"
+            {{- toYaml .Values.worker.resources | nindent 12 }}
           env:
           - name: ENVIRONMENT
             value: {{ .Values.environment | quote }}

--- a/helm/values-release.yaml
+++ b/helm/values-release.yaml
@@ -1,20 +1,12 @@
 # Release/production environment overrides
 # Deploy with: helm install moirai . -f values-release.yaml -n moirai-release
 
-# Use semantic version tag (e.g., :0.6.1, :latest)
-# Update to match the current release version
-api:
-  image:
-    tag: "latest"  # Or pin to specific version like "0.6.1"
-
-ui:
-  image:
-    tag: "latest"  # Or pin to specific version like "0.6.1"
-
-# Production-specific settings
 environment: production
+
 api:
   replicaCount: 2  # Higher availability in production
+  image:
+    tag: "latest"  # Or pin to specific version like "0.6.1"
   readinessProbe:
     initialDelaySeconds: 30
     periodSeconds: 15
@@ -24,3 +16,18 @@ api:
 
 ui:
   replicaCount: 1
+  image:
+    tag: "latest"  # Or pin to specific version like "0.6.1"
+
+# Bump worker memory: at 512Mi the release worker OOMKills under feed-fetch
+# load (~63 feeds / 10 min) combined with OpenAI retry buffering.
+worker:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: "1Gi"
+    limits:
+      cpu: 500m
+      memory: 1Gi
+      ephemeral-storage: "2Gi"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,6 +47,18 @@ ui:
     port: 80
     targetPort: 80
 
+# Enrichment worker (consumes the CouchDB changes feed). Single replica only.
+worker:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+      ephemeral-storage: "1Gi"
+    limits:
+      cpu: 500m
+      memory: 512Mi
+      ephemeral-storage: "2Gi"
+
 nginx:
   replicaCount: 1
   image:

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.8.1-rc.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Release worker (`moirai-release-worker`) is in `CrashLoopBackOff` with 1100+ restarts on the release cluster, OOMKilled at the hardcoded 512Mi memory limit while processing ~63 feeds every 10 min combined with OpenAI retry buffering.
- Parameterises worker resources via `.Values.worker.resources` so they can be tuned per environment instead of being baked into the deployment template.
- Default chart values preserve the previous 128Mi/512Mi behaviour for dev; `values-release.yaml` raises the request to 256Mi and the limit to **1Gi**.
- Also fixes a preexisting bug in `values-release.yaml` where duplicate top-level `api:` and `ui:` keys were silently dropping the `image.tag` overrides.
- Bumps chart/UI version to `0.8.1-rc.1`. Tag will be created on the merge commit per `docs/RELEASE.md`.

## Verification

- \`helm template moirai helm\` renders worker resources at 128Mi/512Mi (unchanged default).
- \`helm template moirai helm -f helm/values-release.yaml\` renders worker resources at 256Mi request / **1Gi** limit.