### PR TITLE
feat(ui): sessions list page at /sessions (Task 1.1)

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -34,6 +34,7 @@ onMounted(() => {
           <router-link to="/chat" class="nav-link">Chat</router-link>
           <router-link to="/settings" class="nav-link">Settings</router-link>
           <router-link to="/agents" class="nav-link">Agents</router-link>
+          <router-link to="/sessions" class="nav-link">Sessions</router-link>
           <a href="#" @click.prevent="handleLogout" class="nav-link logout-link">Logout</a>
         </template>
         <template v-else>

--- a/ui/src/components/SessionsPage.vue
+++ b/ui/src/components/SessionsPage.vue
@@ -199,10 +199,10 @@ onMounted(async () => {
 .error-message {
   padding: 10px 14px;
   margin: 12px 0;
-  background-color: rgba(220, 53, 69, 0.15);
-  border: 1px solid rgba(220, 53, 69, 0.4);
+  background-color: #d9534f;
+  border: 1px solid #b94440;
   border-radius: 4px;
-  color: #f5c2c7;
+  color: white;
 }
 
 .empty-state {
@@ -262,22 +262,22 @@ onMounted(async () => {
 }
 
 .status-pill.status-running {
-  background-color: rgba(74, 144, 226, 0.2);
-  color: #6bb0ff;
+  background-color: #1e5fa8;
+  color: white;
 }
 
 .status-pill.status-success {
-  background-color: rgba(40, 167, 69, 0.2);
-  color: #6fd28a;
+  background-color: #166534;
+  color: white;
 }
 
 .status-pill.status-error {
-  background-color: rgba(220, 53, 69, 0.2);
-  color: #f5c2c7;
+  background-color: #d9534f;
+  color: white;
 }
 
 .status-pill.status-cancelled {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: var(--text-muted, #888);
+  background-color: #6c757d;
+  color: white;
 }
 </style>

--- a/ui/src/components/SessionsPage.vue
+++ b/ui/src/components/SessionsPage.vue
@@ -1,0 +1,283 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { storeToRefs } from 'pinia'
+import { useSessionsStore, type SessionDoc } from '../stores/sessions'
+import { formatDate, formatDuration } from '../utils/formatters'
+
+const router = useRouter()
+const sessionsStore = useSessionsStore()
+const { userspaces, currentUserspace, sessions, loading, loadingUserspaces, error } =
+  storeToRefs(sessionsStore)
+
+const SESSION_TYPE_LABELS: Record<SessionDoc['session_type'], string> = {
+  scheduled_agent: 'Scheduled',
+  on_new_article: 'On New Article',
+  chat: 'Chat',
+}
+
+const STATUS_LABELS: Record<SessionDoc['status'], string> = {
+  running: 'Running',
+  success: 'Success',
+  error: 'Error',
+  cancelled: 'Cancelled',
+}
+
+const hasSessions = computed(() => sessions.value.length > 0)
+
+const onUserspaceChange = async () => {
+  await sessionsStore.loadSessions()
+}
+
+const refresh = () => sessionsStore.loadSessions()
+
+const openSession = (sessionId: string) => {
+  router.push(`/sessions/${sessionId}`)
+}
+
+const sessionTypeLabel = (type: SessionDoc['session_type']) => SESSION_TYPE_LABELS[type] || type
+
+const statusLabel = (status: SessionDoc['status']) => STATUS_LABELS[status] || status
+
+const statusClass = (status: SessionDoc['status']) => `status-${status}`
+
+onMounted(async () => {
+  await sessionsStore.loadUserspaces()
+  await sessionsStore.loadSessions()
+})
+</script>
+
+<template>
+  <div class="sessions-page">
+    <section class="card">
+      <header class="header">
+        <div class="title-block">
+          <h1>Sessions</h1>
+          <p class="muted">Agent runs and chat turns from the last 7 days.</p>
+        </div>
+        <div class="controls">
+          <label class="userspace-picker">
+            <span class="label-text">Userspace</span>
+            <select
+              :value="currentUserspace"
+              :disabled="loadingUserspaces"
+              @change="
+                (e) => {
+                  sessionsStore.setCurrentUserspace((e.target as HTMLSelectElement).value)
+                  onUserspaceChange()
+                }
+              "
+            >
+              <option value="" disabled>
+                {{ loadingUserspaces ? 'Loading…' : 'Select a userspace' }}
+              </option>
+              <option v-for="us in userspaces" :key="us" :value="us">{{ us }}</option>
+            </select>
+          </label>
+          <button type="button" class="refresh-btn" :disabled="loading" @click="refresh">
+            {{ loading ? 'Loading…' : 'Refresh' }}
+          </button>
+        </div>
+      </header>
+
+      <div v-if="error" class="error-message">{{ error }}</div>
+
+      <div v-if="!currentUserspace && !loadingUserspaces" class="empty-state">
+        Select a userspace to see its sessions.
+      </div>
+
+      <div v-else-if="loading && !hasSessions" class="empty-state">Loading sessions…</div>
+
+      <div v-else-if="!hasSessions" class="empty-state">
+        No sessions in the last 7 days for this userspace.
+      </div>
+
+      <table v-else class="sessions-table">
+        <thead>
+          <tr>
+            <th>Started</th>
+            <th>Type</th>
+            <th>Agent</th>
+            <th>Status</th>
+            <th class="numeric">Duration</th>
+            <th class="numeric">Steps</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="session in sessions"
+            :key="session.session_id"
+            class="row"
+            @click="openSession(session.session_id)"
+          >
+            <td>{{ formatDate(session.started_at) }}</td>
+            <td>{{ sessionTypeLabel(session.session_type) }}</td>
+            <td class="agent-cell">{{ session.agent_name || '—' }}</td>
+            <td>
+              <span class="status-pill" :class="statusClass(session.status)">
+                {{ statusLabel(session.status) }}
+              </span>
+            </td>
+            <td class="numeric">{{ formatDuration(session.duration_ms) }}</td>
+            <td class="numeric">{{ session.step_count ?? '—' }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.sessions-page {
+  padding: 20px;
+  overflow-y: auto;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.title-block h1 {
+  margin: 0 0 4px 0;
+}
+
+.muted {
+  color: var(--text-muted, #888);
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.userspace-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label-text {
+  font-size: 0.8rem;
+  color: var(--text-muted, #888);
+}
+
+.userspace-picker select {
+  min-width: 240px;
+  padding: 6px 10px;
+  background-color: var(--card-bg);
+  color: var(--text-color);
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+  border-radius: 4px;
+}
+
+.refresh-btn {
+  padding: 8px 16px;
+  background-color: var(--accent-color, #4a90e2);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.refresh-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error-message {
+  padding: 10px 14px;
+  margin: 12px 0;
+  background-color: rgba(220, 53, 69, 0.15);
+  border: 1px solid rgba(220, 53, 69, 0.4);
+  border-radius: 4px;
+  color: #f5c2c7;
+}
+
+.empty-state {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--text-muted, #888);
+}
+
+.sessions-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+
+.sessions-table th,
+.sessions-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+}
+
+.sessions-table th {
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #888);
+}
+
+.sessions-table .numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.sessions-table .agent-cell {
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row {
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.row:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status-pill.status-running {
+  background-color: rgba(74, 144, 226, 0.2);
+  color: #6bb0ff;
+}
+
+.status-pill.status-success {
+  background-color: rgba(40, 167, 69, 0.2);
+  color: #6fd28a;
+}
+
+.status-pill.status-error {
+  background-color: rgba(220, 53, 69, 0.2);
+  color: #f5c2c7;
+}
+
+.status-pill.status-cancelled {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--text-muted, #888);
+}
+</style>

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -8,6 +8,7 @@ import LoginPage from './components/LoginPage.vue'
 import AgentManagementPage from './components/AgentManagementPage.vue'
 import LifespanView from './components/LifespanView.vue'
 import MythologyPage from './components/MythologyPage.vue'
+import SessionsPage from './components/SessionsPage.vue'
 
 const routes = [
   { path: '/', component: StreamPage, name: 'Stream' }, // Stream is public-ish (or handled by guard)
@@ -24,6 +25,7 @@ const routes = [
     name: 'AgentManagement',
     meta: { requiresAuth: true },
   },
+  { path: '/sessions', component: SessionsPage, name: 'Sessions', meta: { requiresAuth: true } },
 ]
 
 const router = createRouter({

--- a/ui/src/stores/sessions.ts
+++ b/ui/src/stores/sessions.ts
@@ -1,0 +1,99 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { authFetch } from '../utils/authFetch'
+
+export interface SessionDoc {
+  session_id: string
+  session_type: 'scheduled_agent' | 'on_new_article' | 'chat'
+  userspace: string
+  agent_config_id: string | null
+  agent_name: string | null
+  trigger: string | null
+  started_at: string
+  finished_at: string | null
+  duration_ms: number | null
+  status: 'running' | 'success' | 'error' | 'cancelled'
+  error: string | null
+  resolved_llm: Record<string, unknown>
+  llm_calls: number
+  tool_calls: number
+  articles_processed: number
+  step_count?: number
+}
+
+const USERSPACE_STORAGE_KEY = 'moirai_sessions_userspace'
+
+export const useSessionsStore = defineStore('sessions', () => {
+  const userspaces = ref<string[]>([])
+  const currentUserspace = ref<string>(localStorage.getItem(USERSPACE_STORAGE_KEY) || '')
+  const sessions = ref<SessionDoc[]>([])
+  const loading = ref(false)
+  const loadingUserspaces = ref(false)
+  const error = ref<string>('')
+
+  const setCurrentUserspace = (userspace: string) => {
+    currentUserspace.value = userspace
+    if (userspace) {
+      localStorage.setItem(USERSPACE_STORAGE_KEY, userspace)
+    } else {
+      localStorage.removeItem(USERSPACE_STORAGE_KEY)
+    }
+  }
+
+  const loadUserspaces = async () => {
+    loadingUserspaces.value = true
+    error.value = ''
+    try {
+      const response = await authFetch('/api/userspaces')
+      if (!response.ok) {
+        throw new Error(`Failed to load userspaces (${response.status})`)
+      }
+      userspaces.value = await response.json()
+      if (userspaces.value.length > 0 && !userspaces.value.includes(currentUserspace.value)) {
+        setCurrentUserspace(userspaces.value[0])
+      }
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err)
+    } finally {
+      loadingUserspaces.value = false
+    }
+  }
+
+  const loadSessions = async (limit = 50, offset = 0) => {
+    if (!currentUserspace.value) {
+      sessions.value = []
+      return
+    }
+    loading.value = true
+    error.value = ''
+    try {
+      const params = new URLSearchParams({
+        userspace: currentUserspace.value,
+        limit: String(limit),
+        offset: String(offset),
+      })
+      const response = await authFetch(`/api/sessions?${params.toString()}`)
+      if (!response.ok) {
+        throw new Error(`Failed to load sessions (${response.status})`)
+      }
+      sessions.value = await response.json()
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err)
+      sessions.value = []
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    userspaces,
+    currentUserspace,
+    sessions,
+    loading,
+    loadingUserspaces,
+    error,
+    setCurrentUserspace,
+    loadUserspaces,
+    loadSessions,
+  }
+})

--- a/ui/src/utils/formatters.ts
+++ b/ui/src/utils/formatters.ts
@@ -6,11 +6,11 @@
  * Formats an ISO date string into a local-aware readable string.
  */
 export function formatDate(dateStr: string): string {
-  if (!dateStr) return '';
+  if (!dateStr) return ''
   try {
-    return new Date(dateStr).toLocaleString();
+    return new Date(dateStr).toLocaleString()
   } catch (e) {
-    return dateStr;
+    return dateStr
   }
 }
 
@@ -18,20 +18,20 @@ export function formatDate(dateStr: string): string {
  * Strips HTML tags from a string and returns plain text.
  */
 export function stripHtml(html: string): string {
-  if (!html) return '';
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  return doc.body.textContent || "";
+  if (!html) return ''
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  return doc.body.textContent || ''
 }
 
 /**
  * Extracts the hostname from a URL string.
  */
 export function getHostname(urlStr: string): string {
-  if (!urlStr) return '';
+  if (!urlStr) return ''
   try {
-    return new URL(urlStr).hostname;
+    return new URL(urlStr).hostname
   } catch (e) {
-    return urlStr;
+    return urlStr
   }
 }
 
@@ -40,9 +40,26 @@ export function getHostname(urlStr: string): string {
  */
 export function isValidUrl(urlString: string): boolean {
   try {
-    const url = new URL(urlString);
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    const url = new URL(urlString)
+    return url.protocol === 'http:' || url.protocol === 'https:'
   } catch {
-    return false;
+    return false
   }
+}
+
+/**
+ * Formats a duration in milliseconds into a short human-readable string.
+ * Returns '—' for null/undefined.
+ */
+export function formatDuration(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return '—'
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(1)}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.round(seconds % 60)
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return `${hours}h ${remainingMinutes}m`
 }

--- a/ui/src/utils/formatters.ts
+++ b/ui/src/utils/formatters.ts
@@ -56,8 +56,9 @@ export function formatDuration(ms: number | null | undefined): string {
   if (ms < 1000) return `${ms}ms`
   const seconds = ms / 1000
   if (seconds < 60) return `${seconds.toFixed(1)}s`
-  const minutes = Math.floor(seconds / 60)
-  const remainingSeconds = Math.round(seconds % 60)
+  const totalSeconds = Math.round(seconds)
+  const minutes = Math.floor(totalSeconds / 60)
+  const remainingSeconds = totalSeconds % 60
   if (minutes < 60) return `${minutes}m ${remainingSeconds}s`
   const hours = Math.floor(minutes / 60)
   const remainingMinutes = minutes % 60


### PR DESCRIPTION
## Summary
- Adds top-level `/sessions` route + nav link as the first surface consuming the v0.8.0 session timeline backend ([concept doc](../blob/main/docs/observability-intervention-ui.md)).
- New Pinia store `useSessionsStore` centralises userspace selection (persisted to localStorage) and the sessions fetch — reusable by upcoming session detail and approvals work.
- New page shows recent agent runs and chat turns with timestamp, type, agent, status, duration, and step count. Includes userspace picker, refresh, status pills, and empty/loading/error states.
- Adds `formatDuration(ms)` to shared formatters.
- No backend changes — consumes `GET /api/sessions` as shipped in v0.8.0.

## Test plan
- [ ] `cd ui && yarnpkg dev`, navigate to `/sessions`
- [ ] Userspace picker pre-selects the first user-owned userspace; switching reloads the list
- [ ] Empty userspace state: select nothing → "Select a userspace to see its sessions."
- [ ] No sessions state: pick a userspace with no recent activity → "No sessions in the last 7 days for this userspace."
- [ ] Running agent: trigger a SCHEDULED agent or wait for the 60s tick → row appears with status pill "Running", `step_count` populates after finish
- [ ] Refresh button reloads the slice without resetting the userspace
- [ ] Clicking a row pushes to `/sessions/:id` (route lands on Task 1.2; until then vue-router logs an unmatched-route warning)
- [ ] Errors surface in the red error band (try with a userspace that's not user-owned → 403)

## Follow-ups
- Task 1.2: `/sessions/:id` page renders the step timeline.
- Task 1.3: `/approvals` inbox with pending-count nav badge.
- Track 2: Prometheus instrumentation and Grafana dashboards (see [Metrics & Alerting](../blob/main/docs/metrics-and-alerting.md)).

Sliced as one branch per plan item so SonarQube / CI quality gates stay manageable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)