### PR TITLE
fix(ui): regenerate yarn.lock cacheKey for pinned yarn 4.1.0

### DIFF
--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3,7 +3,7 @@
 
 __metadata:
   version: 8
-  cacheKey: 10c0
+  cacheKey: 10
 
 "@babel/generator@npm:^7.28.6":
   version: 7.29.1


### PR DESCRIPTION
## Summary
- PR #166 was committed with a newer yarn (4.9+) that wrote `cacheKey: 10c0` in `ui/yarn.lock` — incompatible with `yarn@4.1.0` pinned in `package.json#packageManager` and used in CI.
- Every PR since (and merges to main) has failed `ui-test` → "Install dependencies (Yarn)" with `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.`
- Running `yarnpkg install` with the pinned yarn 4.1.0 rewrites `cacheKey` back to `10`; no resolutions or checksums change. One-line diff.

## Test plan
- [ ] CI `ui-test` job passes "Install dependencies (Yarn)" step
- [ ] CI `ui-test` proceeds past install and runs the Playwright suite

## Follow-up
Once merged, rebase or merge main into the in-flight feature branches (currently `feat/sessions-list-ui` for #167) to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)