### PR TITLE
fix(ci): enable Corepack before setup-node in docker-release.yml

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -40,6 +40,9 @@ jobs:
         run: |
           conda run -n moirai pytest tests/test_article_processor.py tests/test_live_lwn.py
 
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- docker-release.yml was missing the `corepack enable` step that ci.yml has, so the yarn@4.1.0 packageManager check failed and blocked the v0.8.2 release build.

## Test plan
- CI on this PR should pass the "Run Tests" job past the Node/Yarn setup step.