### PR TITLE
fix(ui): add .dockerignore to prevent stale .yarn state from breaking Docker build

### DIFF
--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,10 @@
+# Local yarn/build state must never enter the image — a host-generated
+# .yarn/install-state.gz overwrites the container's own install state
+# after `COPY . .`, breaking Yarn's node_modules/.bin PATH resolution.
+.yarn
+node_modules
+dist
+
+# Editor/VCS cruft
+.git
+.vscode

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,8 +3,10 @@ FROM node:22-slim AS build-stage
 
 WORKDIR /app
 
-# Copy package.json and yarn.lock to leverage Docker cache
-COPY package.json yarn.lock ./
+# Copy package.json, yarn.lock and .yarnrc.yml to leverage Docker cache
+# (.yarnrc.yml sets nodeLinker: node-modules — must be present before install
+# or Yarn 4 defaults to PnP and yarn build fails to find the node_modules state file)
+COPY package.json yarn.lock .yarnrc.yml ./
 
 # Enable corepack so yarn is available (bundled in node:22 but disabled by default)
 RUN corepack enable && yarn install


### PR DESCRIPTION
## Summary
- `ui/Dockerfile` had no `.dockerignore`, so `COPY . .` copied the host's `.yarn/install-state.gz` into the image, overwriting the container's own freshly-generated install state and breaking Yarn's `node_modules/.bin` PATH resolution (`yarn build` → `command not found: vue-tsc`). Verified with a local reproduction: excluding `.yarn`/`node_modules`/`dist` from the build context fixes it.
- Also copy `.yarnrc.yml` alongside `package.json`/`yarn.lock` before `yarn install`, since it sets `nodeLinker: node-modules` — without it present at install time, Yarn 4 defaults to PnP and the later `yarn build` fails to find the node_modules state file.
- This bug never surfaced in `ci.yml` because that workflow runs a host-side `yarn install` in the same job before the Docker build, so a valid `node_modules` (masking the container's broken install) gets copied in. `docker-release.yml` does a fresh checkout with no such masking, which is where this was caught.

## Test plan
- [x] Local `docker build -f ui/Dockerfile ui/` succeeds end-to-end (vue-tsc type-check + vite build + nginx stage)
- [ ] CI green on this PR