### PR TITLE
deps(docker): bump ui base image to node:26-slim, fix corepack

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -8,8 +8,10 @@ WORKDIR /app
 # or Yarn 4 defaults to PnP and yarn build fails to find the node_modules state file)
 COPY package.json yarn.lock .yarnrc.yml ./
 
-# Node 26 slim doesn't ship corepack by default; install it to activate the pinned Yarn version
-RUN npm install -g corepack@latest && corepack enable && corepack prepare yarn@4.1.0 --activate && yarn install
+# Node 26 slim doesn't ship corepack by default; install it (pinned, no lifecycle
+# scripts) to activate the pinned Yarn version
+ENV YARN_ENABLE_SCRIPTS=false
+RUN npm install -g --ignore-scripts corepack@0.35.0 && corepack enable && corepack prepare yarn@4.1.0 --activate && yarn install
 
 # Copy the rest of the UI source code
 COPY . .

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Vue.js application
-FROM node:22-slim AS build-stage
+FROM node:26-slim AS build-stage
 
 WORKDIR /app
 
@@ -8,11 +8,14 @@ WORKDIR /app
 # or Yarn 4 defaults to PnP and yarn build fails to find the node_modules state file)
 COPY package.json yarn.lock .yarnrc.yml ./
 
-# Enable corepack so yarn is available (bundled in node:22 but disabled by default)
-RUN corepack enable && yarn install
+# Node 26 slim doesn't ship corepack by default; install it to activate the pinned Yarn version
+RUN npm install -g corepack@latest && corepack enable && corepack prepare yarn@4.1.0 --activate && yarn install
 
 # Copy the rest of the UI source code
 COPY . .
+
+# Re-run install after source copy so Yarn's install state matches the final workspace
+RUN yarn install --immutable
 
 # Build arguments placed after dependency install so they don't bust the cache
 ARG APP_VERSION=dev

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -11,7 +11,10 @@ COPY package.json yarn.lock .yarnrc.yml ./
 # Node 26 slim doesn't ship corepack by default; install it (pinned, no lifecycle
 # scripts) to activate the pinned Yarn version
 ENV YARN_ENABLE_SCRIPTS=false
-RUN npm install -g --ignore-scripts corepack@0.35.0 && corepack enable && corepack prepare yarn@4.1.0 --activate && yarn install
+RUN npm install -g --ignore-scripts corepack@0.35.0 \
+    && corepack enable \
+    && corepack prepare yarn@4.1.0 --activate \
+    && yarn install --immutable
 
 # Copy the rest of the UI source code
 COPY . .


### PR DESCRIPTION
## Summary
- Bumps `ui/Dockerfile`'s build stage from `node:22-slim` to `node:26-slim` (same version bump as #172).
- `node:26-slim` doesn't ship Corepack by default the way `node:22-slim` did, so the existing `corepack enable && yarn install` line fails outright on the bump alone (this is exactly why #172's `ui-test` check was red). Installs Corepack explicitly and activates the repo-pinned Yarn `4.1.0` before installing.
- Re-runs `yarn install --immutable` after `COPY . .` so the install state matches the final workspace used by `yarn build` (same reasoning as the fix already worked out in #180).

Verified locally with a full `docker build -f ui/Dockerfile ui` — succeeds and produces a working `dist/` build.

Supersedes:
- #172 (the version bump alone, which fails CI without this)
- #180 (an old branch that already bundled ~15 now-separately-merged commits; the one useful piece — the Corepack fix — is reproduced here cleanly against current `main`)

## Test plan
- [x] `docker build -f ui/Dockerfile ui` succeeds end-to-end (both stages)
- [ ] CI `ui-test` job (will run on this PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018bjRdsrmhSFqx33Rmh61sA